### PR TITLE
Bug fixes and API improvements (2 of 4)

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -36,7 +36,7 @@ var OAuth2 = function(adapterName, config) {
       data.clientId = config.client_id;
       data.clientSecret = config.client_secret;
       data.apiScope = config.api_scope;
-      that.source(data);
+      that.setSource(data);
     }
   });
 };
@@ -66,7 +66,7 @@ if (localStorage.adapterReverse) {
  */
 OAuth2.prototype.updateLocalStorage = function() {
   // Check if update is even required.
-  if (this.source()) {
+  if (this.getSource()) {
     return;
   }
   var data = {};
@@ -84,7 +84,7 @@ OAuth2.prototype.updateLocalStorage = function() {
     }
   }
   // Persist the new JSON object in localStorage.
-  this.source(data);
+  this.setSource(data);
 };
 
 /**
@@ -235,7 +235,7 @@ OAuth2.prototype.finishAuth = function() {
       }
     }
 
-    that.source(data);
+    that.setSource(data);
     callback();
   });
 };
@@ -256,7 +256,7 @@ OAuth2.prototype.isAccessTokenExpired = function() {
  * @return The data object or property value if name was specified.
  */
 OAuth2.prototype.get = function(name) {
-  var src = this.source();
+  var src = this.getSource();
   var obj = src ? JSON.parse(src) : {};
   return name ? obj[name] : obj;
 };
@@ -271,7 +271,7 @@ OAuth2.prototype.get = function(name) {
 OAuth2.prototype.set = function(name, value) {
   var obj = this.get();
   obj[name] = value;
-  this.source(obj);
+  this.setSource(obj);
 };
 
 /**
@@ -284,27 +284,34 @@ OAuth2.prototype.clear = function(name) {
   if (name) {
     var obj = this.get();
     delete obj[name];
-    this.source(obj);
+    this.setSource(obj);
   } else {
     delete localStorage['oauth2_' + this.adapterName];
   }
 };
 
 /**
- * Get the JSON string for the object stored in localStorage. Optionally,
- * provide a new string to be persisted.
+ * Get the JSON string for the object stored in localStorage.
  *
- * @param {String} [source] The new JSON string to be set.
- * @return {String} The source JSON string after any possible changes.
+ * @return {String} The source JSON string.
  */
-OAuth2.prototype.source = function(source) {
-  if (source) {
-    if (typeof source !== 'string') {
-      source = JSON.stringify(source);
-    }
-    localStorage['oauth2_' + this.adapterName] = source;
-  }
+OAuth2.prototype.getSource = function() {
   return localStorage['oauth2_' + this.adapterName];
+};
+
+/**
+ * Set the JSON string for the object stored in localStorage.
+ *
+ * @param {Object|String} source The new JSON string/object to be set.
+ */
+OAuth2.prototype.setSource = function(source) {
+  if (!source) {
+    return;
+  }
+  if (typeof source !== 'string') {
+    source = JSON.stringify(source);
+  }
+  localStorage['oauth2_' + this.adapterName] = source;
 };
 
 /**
@@ -416,7 +423,7 @@ OAuth2.prototype.authorize = function(callback) {
           newData.accessTokenDate = new Date().valueOf();
           newData.accessToken = at;
           newData.expiresIn = exp;
-          that.source(newData);
+          that.setSource(newData);
           // Callback when we finish refreshing
           if (callback) {
             callback();


### PR DESCRIPTION
The second in a series of four pull requests in an attempt to divide the contents of #4.

This contains optimization of `localStorage` usage by limiting the number of variables persisted (achieved by grouping variables in to single objects) and prefixing such variable names as an attempt to avoid conflicts with extensions.

Previous versions don't need to worry as the code will automatically update `localStorage` data. This is only ever done once per adapter, when an adapter is used for the first time after updating.
