### PR TITLE
Support for Content Security Policy

### DIFF
--- a/lib/oauth2.html
+++ b/lib/oauth2.html
@@ -1,34 +1,23 @@
 <!doctype html>
-
 <!--
-Copyright 2011 Google Inc. All Rights Reserved.
+  Copyright 2011 Google Inc. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
 -->
-
-<head>
-  <title>OAuth 2.0 Finish Page</title>
-  <style>
-  </style>
-</head>
-
-<script src="oauth2.js"></script>
-<script>
-  var url = decodeURIComponent(window.location.href.match(/&from=([^&]+)/)[1]);
-  var index = url.indexOf('?');
-  if (index > -1) {
-    url = url.substring(0, index);
-  }
-  var adapterName = OAuth2.lookupAdapterName(url);
-  var finisher = new OAuth2(adapterName, OAuth2.FINISH);
-</script>
+<html>
+  <head>
+    <title>OAuth 2.0 Finish Page</title>
+    <script src="oauth2.js"></script>
+    <script src="oauth2_finish.js"></script>
+  </head>
+</html>

--- a/lib/oauth2_finish.js
+++ b/lib/oauth2_finish.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2011 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This script serves as an intermediary between oauth2.html and oauth2.js.
+
+// Get all query string parameters from the original URL.
+var url = decodeURIComponent(window.location.href.match(/&from=([^&]+)/)[1]);
+var index = url.indexOf('?');
+if (index > -1) {
+  url = url.substring(0, index);
+}
+
+// Derive adapter name from URI and then finish the process.
+var adapterName = OAuth2.lookupAdapterName(url);
+var finisher = new OAuth2(adapterName, OAuth2.FINISH);


### PR DESCRIPTION
This fixes #6 as no inline scripts are used anymore.

[Reason for this change](https://github.com/borismus/oauth2-extensions/pull/7#issuecomment-6322488)
