### PR TITLE
save refreshed refresh token to refresh next time

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -163,7 +163,7 @@ OAuth2.prototype.getAccessAndRefreshTokens = function(authorizationCode, callbac
  * endpoints don't implement refresh tokens.
  *
  * @param {String} refreshToken A valid refresh token
- * @param {Function} callback On success, called with access token and expiry time
+ * @param {Function} callback On success, called with access token and expiry time and refresh token
  */
 OAuth2.prototype.refreshAccessToken = function(refreshToken, callback) {
   var xhr = new XMLHttpRequest();
@@ -174,7 +174,7 @@ OAuth2.prototype.refreshAccessToken = function(refreshToken, callback) {
         // Parse response with JSON
         var obj = JSON.parse(xhr.responseText);
         // Callback with the tokens
-        callback(obj.access_token, obj.expires_in);
+        callback(obj.access_token, obj.expires_in, obj.refresh_token);
       }
     }
   };
@@ -418,11 +418,12 @@ OAuth2.prototype.authorize = function(callback) {
     } else if (that.isAccessTokenExpired()) {
       // There's an existing access token but it's expired
       if (data.refreshToken) {
-        that.refreshAccessToken(data.refreshToken, function(at, exp) {
+        that.refreshAccessToken(data.refreshToken, function(at, exp, re) {
           var newData = that.get();
           newData.accessTokenDate = new Date().valueOf();
           newData.accessToken = at;
           newData.expiresIn = exp;
+          newData.refreshToken = re;
           that.setSource(newData);
           // Callback when we finish refreshing
           if (callback) {


### PR DESCRIPTION
I used this library to connect my service.My service uses doorkeeper(Oauth2 provider for Rails).
Doorkeeper wants to access newer refresh token when access token is expired.
I think it is OAuth2 spec.
So I implemented a hotfix patch.
