### PR TITLE
Fixed - Localstorate lookup fails when urls have only hashtags

### DIFF
--- a/lib/oauth2_finish.js
+++ b/lib/oauth2_finish.js
@@ -22,6 +22,11 @@ var index = url.indexOf('?');
 if (index > -1) {
   url = url.substring(0, index);
 }
+// In cases where the URL contains a # character directly without having a ? char - example http://a.com/bc#code=xys
+index = url.indexOf('#');
+if (index > -1) {
+  url = url.substring(0, index);
+}
 
 // Derive adapter name from URI and then finish the process.
 var adapterName = OAuth2.lookupAdapterName(url);


### PR DESCRIPTION
The lookup in localstorage fails in case the urls contain a # and have no ? character
This is also related to the tweet: https://twitter.com/muslimbit/statuses/252336629744820224
