### PR TITLE
Fix missing scope parameter from the github adaptor

### DIFF
--- a/lib/adapters/github.js
+++ b/lib/adapters/github.js
@@ -5,8 +5,10 @@ OAuth2.adapter('github', {
   authorizationCodeURL: function(config) {
     return ('https://github.com/login/oauth/authorize?' +
       'client_id={{CLIENT_ID}}&' +
+      'scope={{API_SCOPE}}&' +
       'redirect_uri={{REDIRECT_URI}}')
         .replace('{{CLIENT_ID}}', config.clientId)
+        .replace('{{API_SCOPE}}', config.apiScope)
         .replace('{{REDIRECT_URI}}', this.redirectURL(config));
   },
 


### PR DESCRIPTION
Github adaptor was missing the scope parameter, this fixes it.
