### PR TITLE
Update oauth2.js

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -423,7 +423,10 @@ OAuth2.prototype.authorize = function(callback) {
           newData.accessTokenDate = new Date().valueOf();
           newData.accessToken = at;
           newData.expiresIn = exp;
-          newData.refreshToken = re;
+          // refresh token never expires and is not transmited on refresh request (tested with google)
+          if(re){
+            newData.refreshToken = re;
+          }
           that.setSource(newData);
           // Callback when we finish refreshing
           if (callback) {


### PR DESCRIPTION
refresh token never expires and is not transmited on refresh request (tested with google)
