### PR TITLE
Fixed: Race condition in loadAdapter().

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -346,14 +346,23 @@ OAuth2.loadAdapter = function(adapterName, callback) {
     callback();
     return;
   }
-  var head = document.querySelector('head');
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.src = '/oauth2/adapters/' + adapterName + '.js';
+
+  var id = 'oauth2-adapters-' + adapterName;
+  var script = document.getElementById(id);
+
+  if (!script) {
+    var head = document.querySelector('head');
+    script = document.createElement('script');
+    script.id   = id;
+    script.type = 'text/javascript';
+    script.src  = '/oauth2/adapters/' + adapterName + '.js';
+    head.appendChild(script);
+  }
+
   script.addEventListener('load', function() {
     callback();
   });
-  head.appendChild(script);
+
 };
 
 /**


### PR DESCRIPTION
Multiple semi-simultaneous calls to loadAdapter add their own script nodes, and the callbacks sometimes ends up not being called in the order intended. This fix makes sure that there is only ONE script-node per adapter, and adds the callbacks to that node. The event handler appears to call the callbacks in the order they were added to the node, so the initial problem of out-of-order callbacks (calling callback in authorize() before callback in OAuth(), and therefore getting bogus parameters to the OAuth2-tab) is gone.
