### PR TITLE
Fix for the refresh token loss with the Google adapter

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -423,7 +423,7 @@ OAuth2.prototype.authorize = function(callback) {
           newData.accessTokenDate = new Date().valueOf();
           newData.accessToken = at;
           newData.expiresIn = exp;
-          newData.refreshToken = re;
+          newData.refreshToken = re || data.refreshToken;
           that.setSource(newData);
           // Callback when we finish refreshing
           if (callback) {


### PR DESCRIPTION
This fixes the refresh token loss issue when OAuth2 is used with the Google adapter.

I'm creating an issue with more information.
