### PR TITLE
add correct Content-Type to refresh token form

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -181,6 +181,7 @@ OAuth2.prototype.refreshAccessToken = function(refreshToken, callback) {
 
   var data = this.get();
   var formData = new FormData();
+  formData.append('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')
   formData.append('client_id', data.clientId);
   formData.append('client_secret', data.clientSecret);
   formData.append('refresh_token', refreshToken);


### PR DESCRIPTION
The 'refresh token' action was not working for my Chrome extension until I made this change, which is based on this stack overflow solution - http://stackoverflow.com/questions/18820302/using-refresh-token-for-google-oauth-2-0-returns-http-400-bad-request
